### PR TITLE
解决小程序本地无法访问商品详情

### DIFF
--- a/crmeb/services/UtilService.php
+++ b/crmeb/services/UtilService.php
@@ -585,7 +585,8 @@ class UtilService
                 $info["name"] = $name;
                 $info["dir"] = $wapCodePath;
                 $info["time"] = time();
-                $headerArray = get_headers(UtilService::setHttpType($siteUrl, 1) . $info['dir'],true);
+                //$headerArray = get_headers(UtilService::setHttpType($siteUrl, 1) . $info['dir'],true);
+                $headerArray = get_headers(UtilService::setHttpType(str_replace('\\', '', $siteUrl), 1) . $info['dir'], true);
                 $info['size'] = $headerArray['Content-Length'];
                 $info['type'] = $headerArray['Content-Type'];
                 $info["image_type"] = 1;


### PR DESCRIPTION
上传类型应该是从服务器本地上传，我调试了很久，按照下面七牛云，阿里云的把'\’变成'/' ，但是根据我调试的情况，应该把反斜杠去掉