### PR TITLE
修复MySQL 8+ SQL执行报错问题

### DIFF
--- a/crmeb/app/dao/activity/coupon/StoreCouponUserDao.php
+++ b/crmeb/app/dao/activity/coupon/StoreCouponUserDao.php
@@ -176,7 +176,7 @@ class StoreCouponUserDao extends BaseDao
             ->whereMonth('add_time')
             ->whereIn('cid', $where['couponIds'])
             ->field('count(id) as num,FROM_UNIXTIME(add_time, \'%Y-%m\') as time')
-            ->group("FROM_UNIXTIME(add_time, '%Y-%m')")
+            ->group("time")
             ->select()->toArray();
     }
 

--- a/crmeb/app/dao/order/OtherOrderDao.php
+++ b/crmeb/app/dao/order/OtherOrderDao.php
@@ -107,7 +107,7 @@ class OtherOrderDao extends BaseDao
                 $query->field("sum($field) as number,FROM_UNIXTIME($group, '$timeUinx') as time");
                 $query->group("FROM_UNIXTIME($group, '$timeUinx')");
             })
-            ->order('add_time ASC')->select()->toArray();
+            ->order('time ASC')->select()->toArray();
     }
 
     /**根据条件获取单条信息

--- a/crmeb/app/dao/order/StoreOrderDao.php
+++ b/crmeb/app/dao/order/StoreOrderDao.php
@@ -352,9 +352,9 @@ class StoreOrderDao extends BaseDao
                         break;
                 }
                 $query->field("FROM_UNIXTIME(add_time,'$timeUnix') as day,count(*) as count,sum(pay_price) as price");
-                $query->group("FROM_UNIXTIME(add_time, '$timeUnix')");
+                $query->group("day");
             })
-            ->order('add_time asc')
+            ->order('day asc')
             ->select()->toArray();
     }
 
@@ -397,9 +397,9 @@ class StoreOrderDao extends BaseDao
                         break;
                 }
                 $query->field("FROM_UNIXTIME(add_time,'$timeUnix') as day,count(*) as count,sum(pay_price) as price");
-                $query->group("FROM_UNIXTIME(add_time, '$timeUnix')");
+                $query->group("day");
             })
-            ->order('add_time asc')
+            ->order('day asc')
             ->select()->toArray();
     }
 
@@ -712,7 +712,7 @@ class StoreOrderDao extends BaseDao
                     $timeUinx = "%Y-%m";
                 }
                 $query->field("sum($sumField) as number,FROM_UNIXTIME($group, '$timeUinx') as time");
-                $query->group("FROM_UNIXTIME($group, '$timeUinx')");
+                $query->group("time");
             })
             ->order('pay_time ASC,id DESC')->select()->toArray();
     }
@@ -740,7 +740,7 @@ class StoreOrderDao extends BaseDao
                     $timeUinx = "%Y-%m";
                 }
                 $query->field("count($sumField) as number,FROM_UNIXTIME(pay_time, '$timeUinx') as time");
-                $query->group("FROM_UNIXTIME(pay_time, '$timeUinx')");
+                $query->group("time");
             })
             ->order('pay_time ASC,id DESC')->select()->toArray();
     }
@@ -783,7 +783,7 @@ class StoreOrderDao extends BaseDao
                     $timeUinx = "%H";
                 }
                 $query->field("count(distinct uid) as number,FROM_UNIXTIME(pay_time, '$timeUinx') as time");
-                $query->group("FROM_UNIXTIME(pay_time, '$timeUinx')");
+                $query->group("time");
             })
             ->order('pay_time ASC,id DESC')->select()->toArray();
     }

--- a/crmeb/app/dao/order/StoreOrderRefundDao.php
+++ b/crmeb/app/dao/order/StoreOrderRefundDao.php
@@ -166,7 +166,7 @@ class StoreOrderRefundDao extends BaseDao
                     $timeUinx = "%Y-%m";
                 }
                 $query->field("sum($sumField) as number,FROM_UNIXTIME($group, '$timeUinx') as time");
-                $query->group("FROM_UNIXTIME($group, '$timeUinx')");
+                $query->group("time");
             })
             ->order('add_time ASC')->select()->toArray();
     }

--- a/crmeb/app/dao/system/statistics/CapitalFlowDao.php
+++ b/crmeb/app/dao/system/statistics/CapitalFlowDao.php
@@ -69,7 +69,7 @@ class CapitalFlowDao extends BaseDao
         $model = $this->search($where, false)
             ->when(isset($where['type']) && $where['type'] !== '', function ($query) use ($where, $timeUnix) {
                 $query->field("FROM_UNIXTIME(add_time,'$timeUnix') as day,sum(if(price >= 0,price,0)) as income_price,sum(if(price < 0,price,0)) as exp_price,add_time");
-                $query->group("FROM_UNIXTIME(add_time, '$timeUnix')");
+                $query->group("day");
             });
         $count = $model->count();
         $list = $model->when($page && $limit, function ($query) use ($page, $limit) {

--- a/crmeb/app/dao/user/UserBillDao.php
+++ b/crmeb/app/dao/user/UserBillDao.php
@@ -273,7 +273,7 @@ class UserBillDao extends BaseDao
                     $timeUinx = "%Y-%m";
                 }
                 $query->field("sum($field) as number,FROM_UNIXTIME($group, '$timeUinx') as time");
-                $query->group("FROM_UNIXTIME($group, '$timeUinx')");
+                $query->group("time");
             })
             ->order('add_time ASC')->select()->toArray();
     }

--- a/crmeb/app/dao/user/UserDao.php
+++ b/crmeb/app/dao/user/UserDao.php
@@ -249,8 +249,8 @@ class UserDao extends BaseDao
         return $this->getModel()
             ->whereBetweenTime('add_time', $starday, $yesterday)
             ->field("FROM_UNIXTIME(add_time,'%m-%e') as day,count(*) as count")
-            ->group("FROM_UNIXTIME(add_time, '%Y%m%e')")
-            ->order('add_time asc')->select()->toArray();
+            ->group("day")
+            ->order('day asc')->select()->toArray();
     }
 
     /**

--- a/crmeb/app/dao/user/UserExtractDao.php
+++ b/crmeb/app/dao/user/UserExtractDao.php
@@ -112,7 +112,7 @@ class UserExtractDao extends BaseDao
                     $timeUinx = "%Y-%m";
                 }
                 $query->field("sum($field) as number,FROM_UNIXTIME($group, '$timeUinx') as time");
-                $query->group("FROM_UNIXTIME($group, '$timeUinx')");
+                $query->group("time");
             })
             ->order('add_time ASC')->select()->toArray();
     }

--- a/crmeb/app/dao/user/UserMoneyDao.php
+++ b/crmeb/app/dao/user/UserMoneyDao.php
@@ -108,7 +108,7 @@ class UserMoneyDao extends BaseDao
                     $timeUinx = "%Y-%m";
                 }
                 $query->field("sum($field) as number,FROM_UNIXTIME($group, '$timeUinx') as time");
-                $query->group("FROM_UNIXTIME($group, '$timeUinx')");
+                $query->group("time");
             })
             ->order('add_time ASC')->select()->toArray();
     }

--- a/crmeb/app/dao/user/UserRechargeDao.php
+++ b/crmeb/app/dao/user/UserRechargeDao.php
@@ -88,7 +88,7 @@ class UserRechargeDao extends BaseDao
                     $timeUinx = "%Y-%m";
                 }
                 $query->field("sum($field) as number,FROM_UNIXTIME($group, '$timeUinx') as time");
-                $query->group("FROM_UNIXTIME($group, '$timeUinx')");
+                $query->group("time");
             })
             ->order('add_time ASC')->select()->toArray();
 


### PR DESCRIPTION
## 修复MySQL 8+下的GROUP BY兼容性问题

### 问题描述

1. ​**字段别名未传递**  

在MySQL 8.0+环境下运行系统时，管理界面出现SQL语法错误。经排查发现两个因SQL别名使用不一致导致的问题：

![image](https://github.com/user-attachments/assets/48818690-97c8-41a9-8da1-04390078400d)


```php
$query->field("FROM_UNIXTIME(add_time,'$timeUnix') as day, count(*) as count, sum(pay_price) as price");
$query->group("FROM_UNIXTIME(add_time, '$timeUnix')"); // ❌ 使用原始表达式
```

GROUP BY应使用SELECT中定义的别名day而非原始表达式。MySQL 8.0默认的`ONLY_FULL_GROUP_BY`模式导致的严格校验问题。

2. ​ORDER BY与SELECT字段不一致

在crmeb/app/dao/order/StoreOrderDao.php存在select的列和实际orderby的列不一致的情况：

```php
$query->field("sum($field) as number,FROM_UNIXTIME($group, '$timeUinx') as time");
$query->group("FROM_UNIXTIME($group, '$timeUinx')");
})
->order('add_time ASC')->select()->toArray(); // ❌ 应使用别名time
```

附录：报错日志
[20250306_error.log](https://github.com/user-attachments/files/19110716/20250306_error.log)

最后，非常感谢CRMEB团队开源这个项目，以及感谢大佬录制的B站视频。
