### PR TITLE
优化uniapp端登录后跳转

### DIFF
--- a/template/uni-app/libs/login.js
+++ b/template/uni-app/libs/login.js
@@ -66,8 +66,11 @@ function _toLogin(push, pathLogin) {
 	// #endif
 	const BASIC_CONFIG = Cache.get('BASIC_CONFIG')
 	if (!pathLogin)
-		pathLogin = '/page/users/login/index'
-	Cache.set('login_back_url', path);
+		pathLogin = '/pages/users/login/index'
+	//不能等于登录地址，否则登录后还是登录页面
+	if (path !== pathLogin) {
+	        Cache.set('login_back_url', path);
+	}
 	// #ifdef H5
 	if (isWeixin() && BASIC_CONFIG.wechat_status) {
 		uni.navigateTo({


### PR DESCRIPTION
https://github.com/crmeb/CRMEB/blob/fd7e759724454ed40eb6c0918f8e8a5b00beb8bd/template/uni-app/libs/login.js#L65-L70
上述是原有代码，有两个问题：
- `pathLogin` 路径应该是`/pages/users/login/index`而不是`page`，但由于`pathLogin` 没有后续使用，所以没有引发报错。
- `path`不能等于`pathLogin`，否则登录后还是跳转登录页面

目前修改为：
```js
	path = location.pathname + location.search;
	// #endif
	const BASIC_CONFIG = Cache.get('BASIC_CONFIG')
	if (!pathLogin)
		pathLogin = '/pages/users/login/index'
	//不能等于登录地址，否则登录后还是登录页面
	if (path !== pathLogin) {
	        Cache.set('login_back_url', path);
	}
```