### PR TITLE
在 foreach 前增加 isset($themeInfo['value']) 检查，当 value 不存在时跳过遍历

### DIFF
--- a/crmeb/app/api/controller/v1/PublicController.php
+++ b/crmeb/app/api/controller/v1/PublicController.php
@@ -856,7 +856,7 @@ class PublicController
         ], true);
         $themeInfo = app()->make(ThemeServices::class)->getThemeInfo($theme_id, $type);
 
-        if (in_array($type, ['home', 'detail', 'user']) && $themeInfo) {
+        if (in_array($type, ['home', 'detail', 'user']) && $themeInfo && isset($themeInfo['value'])) {
             foreach ($themeInfo['value'] as &$userDataItem) {
                 if ($userDataItem['name'] == 'customerService') {
                     $userDataItem['routine_contact_type'] = (int)sys_config('routine_contact_type');


### PR DESCRIPTION
修复/api/theme_info/category 接口因父分类无二级分类时报`Invalid argument supplied for foreach()"`错误的问题。

此问题发生在H5“分类”页面。

本次问题发生在CRMEB v6中。