### PR TITLE
fix: harden qrcode generation flows

### DIFF
--- a/crmeb/app/adminapi/controller/v1/order/OtherOrder.php
+++ b/crmeb/app/adminapi/controller/v1/order/OtherOrder.php
@@ -72,6 +72,7 @@ class OtherOrder extends AuthController
         $wechatQrcode = $QrcodeService->getWechatQrcodePath($weixinFileName, $weixinPage, false, false);
         //生成小程序地址
         $routineQrcode = $QrcodeService->getRoutineQrcodePath(4, 6, 3, [], false);
+        if ($routineQrcode === 'unpublished') $routineQrcode = '';
         $qrcod = ['wechat' => $wechatQrcode, 'routine' => $routineQrcode];
         $data = [];
         if ($type) {

--- a/crmeb/app/adminapi/controller/v1/user/member/MemberCardBatch.php
+++ b/crmeb/app/adminapi/controller/v1/user/member/MemberCardBatch.php
@@ -100,6 +100,7 @@ class MemberCardBatch extends AuthController
         $wechatQrcode = $QrcodeService->getWechatQrcodePath($weixinFileName,$weixinPage, false, false);
         //生成小程序地址
         $routineQrcode = $QrcodeService->getRoutineQrcodePath(4,6,4, [], false);
+        if ($routineQrcode === 'unpublished') $routineQrcode = '';
         return app('json')->success(['wechat_img' => $wechatQrcode, 'routine' => $routineQrcode ?: ""]);
     }
 

--- a/crmeb/app/api/controller/pc/HomeController.php
+++ b/crmeb/app/api/controller/pc/HomeController.php
@@ -83,6 +83,7 @@ class HomeController
         } else {
             //生成小程序地址
             $codeUrl = $QrcodeService->getRoutineQrcodePath(0, 0, 5, [], false);
+            if ($codeUrl === 'unpublished') $codeUrl = '';
         }
         return app('json')->success(['url' => $codeUrl ?: '']);
     }

--- a/crmeb/app/api/controller/v1/activity/StoreCombinationController.php
+++ b/crmeb/app/api/controller/v1/activity/StoreCombinationController.php
@@ -125,6 +125,7 @@ class StoreCombinationController
         /** @var QrcodeServices $qrcodeService */
         $qrcodeService = app()->make(QrcodeServices::class);
         $url = $qrcodeService->getRoutineQrcodePath($id, $request->uid(), 1);
+        if ($url === 'unpublished') $url = '';
         if ($url) {
             return app('json')->success(['code' => $url]);
         } else {

--- a/crmeb/app/api/controller/v1/activity/StoreSeckillController.php
+++ b/crmeb/app/api/controller/v1/activity/StoreSeckillController.php
@@ -143,6 +143,7 @@ class StoreSeckillController
         /** @var QrcodeServices $qrcodeService */
         $qrcodeService = app()->make(QrcodeServices::class);
         $url = $qrcodeService->getRoutineQrcodePath($id, $request->uid(), 2, ['time_id' => $time_id]);
+        if ($url === 'unpublished') $url = '';
         if ($url) {
             return app('json')->success(['code' => $url]);
         } else {

--- a/crmeb/app/api/controller/v1/user/UserBillController.php
+++ b/crmeb/app/api/controller/v1/user/UserBillController.php
@@ -348,6 +348,14 @@ class UserBillController
     public function getRoutineCode(Request $request)
     {
         $user = $request->user();
+        $routineAppId = trim((string)sys_config('routine_appId', ''));
+        $routineAppSecret = trim((string)sys_config('routine_appsecret', ''));
+        if (!$routineAppId || !$routineAppSecret) {
+            return app('json')->fail('请先配置小程序appid、appSecret等参数');
+        }
+        if (!preg_match('/^wx[a-zA-Z0-9]{16}$/', $routineAppId)) {
+            return app('json')->fail('小程序appid配置错误');
+        }
         /** @var SystemAttachmentServices $systemAttachment */
         $systemAttachment = app()->make(SystemAttachmentServices::class);
         //小程序
@@ -362,8 +370,15 @@ class UserBillController
         /** @var QrcodeServices $qrCode */
         $qrCode = app()->make(QrcodeServices::class);
         if (!$imageInfo) {
-            $resForever = $qrCode->qrCodeForever($user['uid'], 'spread', '', '');
-            $resCode = MiniProgramService::appCodeUnlimitService($resForever->id, '', 280);
+            try {
+                $resForever = $qrCode->qrCodeForever($user['uid'], 'spread', '', '');
+                $resCode = MiniProgramService::appCodeUnlimitService($resForever->id, '', 280);
+            } catch (\Throwable $e) {
+                return app('json')->fail('二维码生成失败');
+            }
+            if (is_object($resCode) && method_exists($resCode, 'getSize') && $resCode->getSize() < 100) {
+                return app('json')->fail('二维码生成失败');
+            }
             if ($resCode) {
                 $res = ['res' => $resCode, 'id' => $resForever->id];
             } else {

--- a/crmeb/app/services/diy/DiyServices.php
+++ b/crmeb/app/services/diy/DiyServices.php
@@ -421,6 +421,10 @@ class DiyServices extends BaseServices
         }
         /** @var QrcodeServices $QrcodeService */
         $QrcodeService = app()->make(QrcodeServices::class);
-        return $QrcodeService->getRoutineQrcodePath($id, 0, 6, [], false);
+        $codeUrl = $QrcodeService->getRoutineQrcodePath($id, 0, 6, [], false);
+        if ($codeUrl === 'unpublished') {
+            throw new AdminException('小程序尚未发布,无法生成二维码');
+        }
+        return $codeUrl;
     }
 }

--- a/crmeb/app/services/order/StoreOrderServices.php
+++ b/crmeb/app/services/order/StoreOrderServices.php
@@ -2680,6 +2680,7 @@ HTML;
             /** @var QrcodeServices $qrcodeService */
             $qrcodeService = app()->make(QrcodeServices::class);
             $orderData['gift_code'] = $qrcodeService->getRoutineQrcodePath($order['id'], $order['uid'], 7, ['gift_key' => $orderData['gift_key']]);
+            if ($orderData['gift_code'] === 'unpublished') $orderData['gift_code'] = '';
         }
         $orderData['avatar'] = set_file_url($orderData['avatar']);
         return $orderData;

--- a/crmeb/app/services/other/QrcodeServices.php
+++ b/crmeb/app/services/other/QrcodeServices.php
@@ -40,6 +40,45 @@ class QrcodeServices extends BaseServices
     }
 
     /**
+     * 获取站点域名配置
+     * @return string
+     */
+    protected function getRequiredSiteUrl(): string
+    {
+        $siteUrl = trim((string)sys_config('site_url'));
+        if ($siteUrl === '') {
+            throw new AdminException('请前往后台设置->系统设置->网站域名 填写您的域名格式为：http://域名');
+        }
+        return $siteUrl;
+    }
+
+    /**
+     * 校验小程序配置
+     * @return void
+     */
+    protected function requireRoutineConfig(): void
+    {
+        if (!sys_config('routine_appId') || !sys_config('routine_appsecret')) {
+            throw new AdminException('请先配置小程序appid、appSecret等参数');
+        }
+    }
+
+    /**
+     * 统一抛出二维码异常
+     * @param \Throwable $e
+     * @param string $defaultMessage
+     * @throws AdminException
+     */
+    protected function throwQrcodeException(\Throwable $e, string $defaultMessage = '二维码生成失败')
+    {
+        if ($e instanceof AdminException) {
+            throw $e;
+        }
+        $message = trim($e->getMessage()) ?: $defaultMessage;
+        throw new AdminException($message, [], $e->getCode() ?: 400, $e);
+    }
+
+    /**
      * 获取临时二维码
      * @param $type
      * @param $id
@@ -142,12 +181,13 @@ class QrcodeServices extends BaseServices
         $systemAttchment = app()->make(SystemAttachmentServices::class);
         try {
             $imageInfo = $systemAttchment->getInfo(['name' => $name]);
-            $siteUrl = sys_config('site_url');
+            $siteUrl = $this->getRequiredSiteUrl();
             if (!$imageInfo) {
                 $codeUrl = PosterServices::setHttpType($siteUrl . $link, request()->isSsl() ? 0 : 1);//二维码链接
                 $imageInfo = PosterServices::getQRCodePath($codeUrl, $name);
-                if (is_string($imageInfo) && $force)
-                    return false;
+                if (is_string($imageInfo)) {
+                    throw new AdminException($imageInfo);
+                }
                 if (is_array($imageInfo)) {
                     $systemAttchment->attachmentAdd($imageInfo['name'], $imageInfo['size'], $imageInfo['type'], $imageInfo['dir'], $imageInfo['thumb_path'], 1, $imageInfo['image_type'], $imageInfo['time'], 2);
                     $url = $imageInfo['dir'];
@@ -159,10 +199,7 @@ class QrcodeServices extends BaseServices
             if ($imageInfo['image_type'] == 1 && $url) $url = $siteUrl . $url;
             return $url;
         } catch (\Throwable $e) {
-            if ($force)
-                return false;
-            else
-                return '';
+            return $force ? false : '';
         }
     }
 
@@ -183,12 +220,13 @@ class QrcodeServices extends BaseServices
             } else {
                 $imageInfo = $systemAttachmentService->getOne(['name' => $name]);
             }
-            $siteUrl = sys_config('site_url');
+            $siteUrl = $this->getRequiredSiteUrl();
             if (!$imageInfo) {
                 $codeUrl = PosterServices::setHttpType($siteUrl . $link, request()->isSsl() ? 0 : 1);//二维码链接
                 $imageInfo = PosterServices::getQRCodePath($codeUrl, $name);
-                if (is_string($imageInfo) && $force)
-                    return false;
+                if (is_string($imageInfo)) {
+                    throw new AdminException($imageInfo);
+                }
                 if (is_array($imageInfo)) {
                     if ($isSaveAttach) {
                         $systemAttachmentService->save([
@@ -213,10 +251,7 @@ class QrcodeServices extends BaseServices
             if ($imageInfo['image_type'] == 1 && $url) $url = $siteUrl . $url;
             return $url;
         } catch (\Throwable $e) {
-            if ($force)
-                return false;
-            else
-                return '';
+            return $force ? false : '';
         }
     }
 
@@ -275,28 +310,33 @@ class QrcodeServices extends BaseServices
             return false;
         }
         try {
+            $this->requireRoutineConfig();
             if (!$isSaveAttach) {
                 $imageInfo = "";
             } else {
                 $imageInfo = $systemAttachmentService->getOne(['name' => $namePath]);
             }
-            $siteUrl = sys_config('site_url');
+            $siteUrl = $this->getRequiredSiteUrl();
             if (!$imageInfo) {
                 $res = MiniProgramService::appCodeUnlimitService($data, $page, 280);
-                if (!$res) return false;
+                if (!$res) {
+                    throw new AdminException('二维码生成失败');
+                }
                 if ($res->getSize() < 100) return 'unpublished';
                 $uploadType = (int)sys_config('upload_type', 1);
                 $upload = UploadService::init();
                 $res = (string)EntityBody::factory($res);
                 $res = $upload->to('routine/product')->validate()->setAuthThumb(false)->stream($res, $namePath);
                 if ($res === false) {
-                    return false;
+                    throw new AdminException($upload->getError() ?: '二维码生成失败');
                 }
                 $imageInfo = $upload->getUploadInfo();
                 $imageInfo['image_type'] = $uploadType;
                 if ($imageInfo['image_type'] == 1) $remoteImage = PosterServices::remoteImage($siteUrl . $imageInfo['dir']);
                 else $remoteImage = PosterServices::remoteImage($imageInfo['dir']);
-                if (!$remoteImage['status']) return false;
+                if (!$remoteImage['status']) {
+                    throw new AdminException($remoteImage['msg'] ?? '二维码生成失败');
+                }
                 if ($isSaveAttach) {
                     $systemAttachmentService->save([
                         'name' => $imageInfo['name'],

--- a/crmeb/app/services/product/product/StoreProductServices.php
+++ b/crmeb/app/services/product/product/StoreProductServices.php
@@ -670,6 +670,10 @@ class StoreProductServices extends BaseServices
                 $data['activity'][$k] = 0;
             }
         }
+        foreach ($detail as &$item) {
+            $item['is_default_select'] = (int)($item['is_default_select'] ?? 0);
+        }
+        unset($item);
 
         if ($data['spec_type'] == 1) {
             $defaultItems = array_filter($detail, function ($item) {
@@ -684,6 +688,7 @@ class StoreProductServices extends BaseServices
                 $filtered = array_filter($detail, function ($item) {
                     return $item['is_show'] == 1;
                 });
+                $data['default_sku'] = '';
                 $data['price'] = min(array_column($filtered, 'price'));
                 $data['ot_price'] = min(array_column($filtered, 'ot_price'));
                 $data['cost'] = isset($data['cost']) ? min(array_column($filtered, 'cost')) : 0;
@@ -1130,6 +1135,7 @@ class StoreProductServices extends BaseServices
             $valueNew[$count]['brokerage'] = $sukValue[$suk]['brokerage'] ? floatval($sukValue[$suk]['brokerage']) : 0;
             $valueNew[$count]['brokerage_two'] = $sukValue[$suk]['brokerage_two'] ? floatval($sukValue[$suk]['brokerage_two']) : 0;
             $valueNew[$count]['vip_price'] = $sukValue[$suk]['vip_price'] ? floatval($sukValue[$suk]['vip_price']) : 0;
+            $valueNew[$count]['is_default_select'] = (int)($sukValue[$suk]['is_default_select'] ?? 0);
             $count++;
         }
         $header[] = ['title' => '图片', 'slot' => 'pic', 'align' => 'center', 'minWidth' => 120];
@@ -2201,18 +2207,51 @@ class StoreProductServices extends BaseServices
         if (!$id || !$this->isValidProduct($id, 'id')) {
             throw new ApiException('商品不存在');
         }
-        if ($userType == 'routine') {
+        try {
             /** @var QrcodeServices $qrcodeService */
             $qrcodeService = app()->make(QrcodeServices::class);
-            $url = $qrcodeService->getRoutineQrcodePath($id, $user['uid'], 0, ['is_promoter' => $user['is_promoter']]);
-            if (!$url) {
-                throw new ApiException('二维码生成失败');
-            } else {
+            $uid = (int)($user['uid'] ?? 0);
+            $isPromoter = (int)($user['is_promoter'] ?? 0);
+            if ($userType == 'routine') {
+                if (!sys_config('routine_appId') || !sys_config('routine_appsecret')) {
+                    throw new ApiException('请先配置小程序appid、appSecret等参数');
+                }
+                $url = $qrcodeService->getRoutineQrcodePath($id, $uid, 0, ['is_promoter' => $isPromoter]);
                 if ($url == 'unpublished') throw new ApiException('小程序尚未发布,无法生成商品海报');
+                if (!$url) throw new ApiException('二维码生成失败');
                 return $url;
             }
+            if ($userType == 'wechat') {
+                if (sys_config('share_qrcode', 0)) {
+                    if (!sys_config('wechat_appid') || !sys_config('wechat_appsecret')) {
+                        throw new ApiException('请先配置公众号appid、appSecret等参数');
+                    }
+                    $url = $qrcodeService->getTemporaryQrcode('product-' . $id, $uid)->url;
+                    if (!$url) throw new ApiException('二维码生成失败');
+                    return $url;
+                }
+                $userType = 'h5';
+            }
+            if ($userType == 'h5') {
+                if (trim((string)sys_config('site_url')) === '') {
+                    throw new ApiException('请前往后台设置->系统设置->网站域名 填写您的域名格式为：http://域名');
+                }
+                $name = $id . '_' . $uid . '_' . $isPromoter . '_product_wap.jpg';
+                $link = '/pages/goods_details/index?id=' . $id;
+                if ($uid) {
+                    $link .= '&spread=' . $uid;
+                }
+                $url = $qrcodeService->getWechatQrcodePath($name, $link);
+                if (!$url) throw new ApiException('二维码生成失败');
+                return $url;
+            }
+            throw new ApiException('暂不支持该类型二维码');
+        } catch (\Throwable $e) {
+            if ($e instanceof ApiException) {
+                throw $e;
+            }
+            throw new ApiException($e->getMessage() ?: '二维码生成失败');
         }
-        return '';
     }
 
     /**


### PR DESCRIPTION
## Summary
- restore QR code service fallback contracts for H5/wechat/routine paths
- handle unpublished mini-program QR results in callers
- add explicit business errors for product poster QR generation
- clear stale default_sku when all SKU default selections are removed

## Verification
- php -l passed for all 10 changed PHP files
- /adminapi/login/info returned HTTP 200 / status 200
- /api/product/code/1?user_type=h5 returned HTTP 200 / business status 400 with expected site_url message
- /api/user/routine_code returned HTTP 200 / business status 400 when routine config is empty