### PR TITLE
perf: enable database fields cache

### DIFF
--- a/crmeb/config/database.php
+++ b/crmeb/config/database.php
@@ -59,6 +59,8 @@ return [
             'slave_no'        => '',
             // 是否严格检查字段是否存在
             'fields_strict'   => true,
+            // 缓存表字段元数据，减少新进程重复 SHOW FULL COLUMNS 开销
+            'fields_cache'    => true,
             // 是否需要进行SQL性能分析
             'sql_explain'     => false,
             // Builder类


### PR DESCRIPTION
## Summary
- enable Think ORM fields_cache to reduce repeated table metadata queries
- keep product detail performance fix limited to database config

## Verification
- php -l passed for crmeb/config/database.php
- /api/product/detail/1 returned HTTP 200 / status 200
- curl timing average improved from about 6.83s to 6.44s in the same local environment