### PR TITLE
fix: enforce MCP outapi permissions

### DIFF
--- a/crmeb/app/outapi/controller/Mcp.php
+++ b/crmeb/app/outapi/controller/Mcp.php
@@ -76,7 +76,7 @@ class Mcp extends AuthController
             $this->outInfo = $accountInfo;
 
             // 验证接口权限（参考 AuthTokenMiddleware）
-            // $this->verifyAuth();
+            $this->verifyAuth();
 
         } catch (\crmeb\exceptions\AuthException $e) {
             // AuthException 转换为友好错误


### PR DESCRIPTION
## Summary
- restore MCP outapi permission verification after account authentication
- keep the existing outapi permission model unchanged

## Verification
- php -l passed for crmeb/app/outapi/controller/Mcp.php
- unauthenticated /outapi/mcp request returns JSON-RPC authentication error
- invalid account/password returns account not found