### PR TITLE
chore: stabilize docker php performance baseline

### DIFF
--- a/help/docker/docker-compose.yml
+++ b/help/docker/docker-compose.yml
@@ -1,3 +1,5 @@
+name: crmeb
+
 services:
   # mysql 容器
   mysql:
@@ -29,11 +31,21 @@ services:
     networks:
       app_net:
         ipv4_address: 192.168.10.10
+  vendor-init:
+    image: ccr.ccs.tencentyun.com/crmebky_php/php:v7.4
+    command: sh -lc 'if [ ! -f /vendor/autoload.php ]; then cp -a /host-vendor/. /vendor/; fi'
+    network_mode: none
+    volumes:
+      - ../../crmeb/vendor:/host-vendor:ro
+      - crmeb_vendor:/vendor
   # php 容器
   phpfpm:
     container_name: crmeb_php
     image: ccr.ccs.tencentyun.com/crmebky_php/php:v7.4
     restart: always
+    depends_on:
+      vendor-init:
+        condition: service_completed_successfully
     environment:
       TZ: Asia/Shanghai
       MYSQL_HOST_IP: crmeb_mysql
@@ -55,6 +67,8 @@ services:
     volumes:
       - ../../crmeb:/var/www
       - ../../crmeb/runtime:/var/www/runtime
+      - crmeb_vendor:/var/www/vendor
+      - ./php/opcache.ini:/usr/local/etc/php/conf.d/docker-php-ext-opcache.ini:ro
     networks:
       app_net:
         ipv4_address: 192.168.10.90
@@ -85,3 +99,7 @@ networks:
       driver: default
       config:
         - subnet: 192.168.10.0/24
+
+volumes:
+  crmeb_vendor:
+    name: crmeb_vendor

--- a/help/docker/php/opcache.ini
+++ b/help/docker/php/opcache.ini
@@ -1,0 +1,13 @@
+zend_extension=opcache.so
+
+opcache.enable=1
+opcache.enable_cli=1
+opcache.memory_consumption=256
+opcache.interned_strings_buffer=16
+opcache.max_accelerated_files=20000
+opcache.validate_timestamps=1
+opcache.revalidate_freq=2
+opcache.save_comments=1
+
+realpath_cache_size=16M
+realpath_cache_ttl=600


### PR DESCRIPTION
## Summary
- pin the compose project name to avoid cross-project service confusion
- mount vendor from a Docker volume to avoid slow Windows bind-mount scans
- add a vendor-init helper to seed the vendor volume
- enable OPcache and realpath cache for the PHP container

## Verification
- docker compose -p crmeb -f help/docker/docker-compose.yml config --quiet passed
- crmeb_mysql, crmeb_redis, crmeb_php, and crmeb_nginx are Up
- php -m shows Zend OPcache
- php think list runs normally
- dynamic endpoints dropped from ~15-20s to ~1-3s in the local Docker environment